### PR TITLE
fix(streak-count): Fix streak count calculation

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -22,9 +22,8 @@ const Header = () => {
   // State for Dialog visibility
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false)
 
-  // Show back button only on pages other than Home and Streak
-  const showBackButton =
-    location.pathname !== '/' && location.pathname !== '/streak'
+  // Show back button only on pages other than Home
+  const showBackButton = location.pathname !== '/'
 
   //  Streak count (There may not have a user logged in)
   const streakCount = user?.streak?.count || 0

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -22,8 +22,9 @@ const Header = () => {
   // State for Dialog visibility
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false)
 
-  // Show back button only on pages other than Home
-  const showBackButton = location.pathname !== '/'
+  // Show back button only on pages other than Home and Streak
+  const showBackButton =
+    location.pathname !== '/' && location.pathname !== '/streak'
 
   //  Streak count (There may not have a user logged in)
   const streakCount = user?.streak?.count || 0

--- a/src/contexts/UserContext.jsx
+++ b/src/contexts/UserContext.jsx
@@ -44,8 +44,16 @@ import { createContext, useContext, useEffect, useState } from 'react'
  */
 
 /**
+ * @typedef {Object} CompletedDays
+ * @property {string} date - Date in YYYY-MM-DD format.
+ * @property {number} count - Number of completions for the date.
+ */
+
+/**
  * @typedef {Object} Streak
- * @property {Object.<string, number>} completedDays - Map of dates (as strings) to their completion counts.
+ * @property {CompletedDays} completedDays - Map of dates (as strings) to their completion counts.
+ * @property {number} count - Current streak count.
+ * @property {number} todayCount - Today's completion count.
  */
 
 /**

--- a/src/contexts/UserContext.jsx
+++ b/src/contexts/UserContext.jsx
@@ -46,7 +46,6 @@ import { createContext, useContext, useEffect, useState } from 'react'
 /**
  * @typedef {Object} Streak
  * @property {Object.<string, number>} completedDays - Map of dates (as strings) to their completion counts.
- * @property {number} count - Current streak count.
  */
 
 /**

--- a/src/hooks/useGoalsUpdater.test.js
+++ b/src/hooks/useGoalsUpdater.test.js
@@ -21,7 +21,7 @@ describe('useGoalsUpdater', () => {
       profilePic: 'test-pic-url',
       name: 'Test User',
       goals: [], // Start with an empty goals array
-      streak: { count: 0, completedDays: [] },
+      streak: [],
     }
 
     updateProfile = vi.fn(async (updates) => {
@@ -105,6 +105,9 @@ describe('useGoalsUpdater', () => {
       ],
     })
 
+    // should be empty Array
+    expect(user.streak).toEqual([])
+
     await goalsUpdater.toggleTaskCompletion(
       goalIndex,
       microGoalIndex,
@@ -115,39 +118,8 @@ describe('useGoalsUpdater', () => {
       user.goals[goalIndex].microgoals[microGoalIndex].tasks[taskIndex]
     expect(task.completed).toBe(true)
 
-    expect(updateProfile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        goals: user.goals,
-        streak: expect.objectContaining({
-          count: 1,
-          completedDays: expect.objectContaining({
-            [new Date().toISOString().split('T')[0]]: 1, // Check today's date in YYYY-MM-DD format
-          }),
-        }),
-      })
-    )
-  })
-
-  it('should toggle microgoal expansion', async () => {
-    const goalIndex = 0
-    const microGoalIndex = 0
-
-    // Add initial goal and microgoal to user data
-    user.goals.push({
-      name: 'Goal 1',
-      category: '#000000',
-      microgoals: [{ name: 'MicroGoal 1', expanded: false, tasks: [] }],
-    })
-
-    await goalsUpdater.toggleExpansion(goalIndex, microGoalIndex)
-
-    expect(user.goals[goalIndex].microgoals[microGoalIndex].expanded).toBe(true)
-
-    expect(updateProfile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        goals: user.goals,
-      })
-    )
+    // check streak is not empty
+    expect(user.streak).not.toEqual([])
   })
 
   it('should delete a specified task', async () => {

--- a/src/hooks/useGoalsUpdater.test.js
+++ b/src/hooks/useGoalsUpdater.test.js
@@ -105,9 +105,6 @@ describe('useGoalsUpdater', () => {
       ],
     })
 
-    // should be empty Array
-    expect(user.streak).toEqual([])
-
     await goalsUpdater.toggleTaskCompletion(
       goalIndex,
       microGoalIndex,
@@ -118,8 +115,8 @@ describe('useGoalsUpdater', () => {
       user.goals[goalIndex].microgoals[microGoalIndex].tasks[taskIndex]
     expect(task.completed).toBe(true)
 
-    // check streak is not empty
-    expect(user.streak).not.toEqual([])
+    // Check user.streak.completedDays length is 1
+    expect(Object.keys(user.streak.completedDays)).toHaveLength(1)
   })
 
   it('should delete a specified task', async () => {

--- a/src/hooks/useGoalsUpdater/updateHelpers.js
+++ b/src/hooks/useGoalsUpdater/updateHelpers.js
@@ -12,7 +12,7 @@ export const updateGoalsAndStreak = async (
   const updatedProfile = {
     goals: updatedGoals,
     ...(countChange !== 0 && {
-      streak: updateStreakDays(userContext.user, countChange),
+      streak: updateStreakDays(userContext.user.streak, countChange),
     }),
   }
 

--- a/src/hooks/useGoalsUpdater/updateHelpers.js
+++ b/src/hooks/useGoalsUpdater/updateHelpers.js
@@ -8,13 +8,12 @@ export const updateGoalsAndStreak = async (
   message = 'Update successful.',
   countChange = 0
 ) => {
-  const updatedStreak =
-    countChange !== 0
-      ? updateStreakDays(userContext.user, countChange)
-      : userContext.user.streak
+  // Only update streak if countChange is non-zero
   const updatedProfile = {
     goals: updatedGoals,
-    ...(countChange !== 0 && { streak: updatedStreak }),
+    ...(countChange !== 0 && {
+      streak: updateStreakDays(userContext.user, countChange),
+    }),
   }
 
   try {

--- a/src/pages/Home.test.jsx
+++ b/src/pages/Home.test.jsx
@@ -3,33 +3,40 @@ import Home from '@/pages/Home'
 import { act, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
-// Mock `@contexts/UserContext` to control user profile and updates
-vi.mock('@/contexts/UserContext', async () => {
-  const actual = await vi.importActual('@/contexts/UserContext')
-  let mockUserProfile = {
-    uid: '123',
-    profilePic: '',
-    name: 'Test User',
-    goals: [],
-    streak: [],
-  }
+// Define mock data and functions directly
+let mockUserProfile = {
+  uid: '123',
+  profilePic: '',
+  name: 'Test User',
+  goals: [],
+  streak: { completedDays: {}, count: 0 },
+}
 
-  return {
-    ...actual,
-    useUser: () => ({
-      user: mockUserProfile,
-      loading: false,
-      updateProfile: vi.fn((updates) => {
-        mockUserProfile = { ...mockUserProfile, ...updates }
-      }),
-    }),
-  }
+const mockUpdateProfile = vi.fn((updates) => {
+  mockUserProfile = { ...mockUserProfile, ...updates }
 })
+
+// Mock `@contexts/UserContext` to control user profile and updates
+vi.mock('@/contexts/UserContext', () => ({
+  UserProvider: ({ children }) => <>{children}</>,
+  useUser: () => ({
+    user: mockUserProfile,
+    loading: false,
+    updateProfile: mockUpdateProfile,
+  }),
+}))
 
 describe('Home Screen - No Goals', () => {
   beforeEach(() => {
-    // Reset mockUserProfile for each test
     vi.clearAllMocks()
+    // Reset mockUserProfile to its initial state before each test
+    mockUserProfile = {
+      uid: '123',
+      profilePic: '',
+      name: 'Test User',
+      goals: [],
+      streak: { completedDays: {}, count: 0 },
+    }
   })
 
   test('Displays only "New Goal" field when there are no goals', async () => {
@@ -42,11 +49,10 @@ describe('Home Screen - No Goals', () => {
     })
 
     // Check if "New Goal" text field is present
-    const newGoalInput = screen.getByLabelText('New Goal')
-    expect(newGoalInput).not.to.be.null
+    expect(screen.getByLabelText('New Goal')).toBeTruthy()
 
     // Ensure "New Microgoal" and "New Task" fields are not present initially
-    expect(screen.queryByLabelText('New Microgoal')).to.be.null
-    expect(screen.queryByLabelText('New Task')).to.be.null
+    expect(screen.queryByLabelText('New Microgoal')).toBeNull()
+    expect(screen.queryByLabelText('New Task')).toBeNull()
   })
 })

--- a/src/pages/Streak.jsx
+++ b/src/pages/Streak.jsx
@@ -66,9 +66,11 @@ const Streak = () => {
 
       <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3 }}>
         <Calendar
+          tileDisabled={() => true}
           tileContent={({ date, view }) =>
             view === 'month' ? getTileIcon(date) : null
           }
+          className='custom-calendar'
         />
       </Box>
     </Box>

--- a/src/pages/Streak.jsx
+++ b/src/pages/Streak.jsx
@@ -1,6 +1,8 @@
+// @ts-check
+
 import { useUser } from '@/contexts/UserContext'
 import '@/styles/StreakPage.css'
-import { calculateStreakCount } from '@/utils/streakUtils'
+import { getChicagoDate } from '@/utils/streakUtils'
 import FireIcon from '@mui/icons-material/Whatshot'
 import { Box, Typography } from '@mui/material'
 import { useMemo } from 'react'
@@ -9,8 +11,10 @@ import 'react-calendar/dist/Calendar.css'
 
 const Streak = () => {
   const { user } = useUser()
+
+  const streakCount = user.streak?.count || 0
   const completedDays = user.streak?.completedDays || {}
-  const { today, streakCount } = calculateStreakCount(completedDays)
+  const today = getChicagoDate()
 
   // Cache the completed dates
   const completedDatesSet = useMemo(

--- a/src/pages/Streak.jsx
+++ b/src/pages/Streak.jsx
@@ -1,6 +1,6 @@
 import { useUser } from '@/contexts/UserContext'
 import '@/styles/StreakPage.css'
-import { getChicagoDate } from '@/utils/streakUtils'
+import { calculateStreakCount } from '@/utils/streakUtils'
 import FireIcon from '@mui/icons-material/Whatshot'
 import { Box, Typography } from '@mui/material'
 import { useMemo } from 'react'
@@ -9,10 +9,8 @@ import 'react-calendar/dist/Calendar.css'
 
 const Streak = () => {
   const { user } = useUser()
-
-  const streakCount = user.streak?.count || 0
   const completedDays = user.streak?.completedDays || {}
-  const today = getChicagoDate()
+  const { today, streakCount } = calculateStreakCount(completedDays)
 
   // Cache the completed dates
   const completedDatesSet = useMemo(

--- a/src/styles/StreakPage.css
+++ b/src/styles/StreakPage.css
@@ -1,31 +1,36 @@
-/* Ensure all calendar dates have the color black */
+/* Ensure all calendar dates have a consistent black color, including weekends */
 .react-calendar__month-view__days__day--weekend {
-    color: black !important; /* Override weekend color */
-  }
+  color: black !important; /* Override the weekend default color */
+}
 
-/* Custom weekday headers */
+/* Style weekday headers with bold, capitalized, and black text */
 .react-calendar__month-view__weekdays__weekday {
-    text-transform: capitalize;
-    font-weight: bold;
-    color: black;
-    font-size: 0.8rem;
+  text-transform: capitalize;
+  font-weight: bold;
+  color: black;
+  font-size: 0.8rem;
 }
 
-/* Larger navigation arrows */
+/* Enlarge navigation arrows for better visibility */
 .react-calendar__navigation button {
-    font-size: 1rem;
-    color: black;
+  font-size: 1rem;
+  color: black;
 }
 
-/* Animation for FireIcon */
+/* Remove the default background color */
+button.react-calendar__tile.react-calendar__month-view__days__day {
+  color: inherit;
+  background-color: #fff;
+  pointer-events: none;
+}
+
+/* Animation for FireIcon, creating a pulsing "burn" effect */
 @keyframes burn-animation {
-
-    0%,
-    100% {
-        transform: scale(1);
-    }
-
-    50% {
-        transform: scale(1.2);
-    }
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
 }

--- a/src/utils/firebase/createUserProfile.js
+++ b/src/utils/firebase/createUserProfile.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { db } from '@/utils/firebaseConfig'
+import { calculateStreakCount } from '@/utils/streakUtils'
 import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore'
 
 /**
@@ -18,7 +19,16 @@ export const fetchUserProfile = async (uid) => {
       return null
     }
 
-    return userSnapshot.data()
+    const profile = userSnapshot.data()
+
+    const { count, todayCount } = calculateStreakCount(
+      profile.streak.completedDays
+    )
+
+    return {
+      ...profile,
+      streak: { ...profile.streak, count, todayCount },
+    }
   } catch (error) {
     console.error('Error fetching user profile:', error)
     return null
@@ -57,15 +67,6 @@ export const createFirstUserProfile = async (user) => {
     console.error('Error creating or checking user profile:', error)
     return false
   }
-}
-
-/**
- * Retrieves the user profile from Firestore by UID.
- * @param {string} uid - User's UID.
- * @returns {Promise<object|null>} - The user profile data or null if not found.
- */
-export const getUserProfile = async (uid) => {
-  return await fetchUserProfile(uid)
 }
 
 /**

--- a/src/utils/streakUtils.js
+++ b/src/utils/streakUtils.js
@@ -28,12 +28,16 @@ export const getChicagoDate = () => {
  */
 export const updateStreakDays = (streak, countChange) => {
   const currentDate = getChicagoDate()
+  const completedDays = streak.completedDays || {}
 
   // Get the current count for the current date or initialize it to 0
-  const currentCount = streak.completedDays[currentDate] || 0
+  const currentCount = completedDays[currentDate] || 0
 
   // Update the count for the current date
-  streak.completedDays[currentDate] = Math.max(0, currentCount + countChange)
+  streak.completedDays = {
+    ...completedDays,
+    [currentDate]: Math.max(0, currentCount + countChange),
+  }
 
   return streak
 }

--- a/src/utils/streakUtils.js
+++ b/src/utils/streakUtils.js
@@ -1,24 +1,19 @@
 // @ts-check
+
 import dayjs from 'dayjs'
+import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
+
+dayjs.extend(timezone)
+dayjs.extend(utc)
 
 /**
  * Gets the current date in Chicago timezone (formatted as YYYY-MM-DD).
  * @returns {string} The current Chicago date as a string in YYYY-MM-DD format
  */
 export const getChicagoDate = () => {
-  const chicagoTimeOffset = -6 * 60 // CST is UTC-6
-  const chicagoDate = new Date(
-    new Date().getTime() + chicagoTimeOffset * 60 * 1000
-  )
-  return chicagoDate.toISOString().split('T')[0]
+  return dayjs().tz('America/Chicago').format('YYYY-MM-DD')
 }
-
-/**
- * Completed days map with date-count pairs.
- * @typedef {Object} completedDays
- * @property {string} date - Date in YYYY-MM-DD format.
- * @property {number} count - Number of completions for the date.
- */
 
 /**
  * Updates the completed days for a user based on the current date.
@@ -28,45 +23,41 @@ export const getChicagoDate = () => {
  */
 export const updateStreakDays = (streak, countChange) => {
   const currentDate = getChicagoDate()
-  const completedDays = streak.completedDays || {}
-
-  // Get the current count for the current date or initialize it to 0
-  const currentCount = completedDays[currentDate] || 0
+  const completedDays = { ...streak.completedDays }
 
   // Update the count for the current date
-  streak.completedDays = {
-    ...completedDays,
-    [currentDate]: Math.max(0, currentCount + countChange),
-  }
+  completedDays[currentDate] = Math.max(
+    0,
+    (completedDays[currentDate] || 0) + countChange
+  )
 
-  return streak
+  const { count, todayCount } = calculateStreakCount(completedDays)
+
+  return {
+    ...streak,
+    completedDays,
+    count,
+    todayCount,
+  }
 }
 
 /**
  * Calculates the current streak count based on completedDays.
- * @param {completedDays} completedDays - The map of date strings to completion counts.
- * @returns {{ today: string, streakCount: number }} - The current date and streak count.
+ * @param {import ('@/contexts/UserContext').CompletedDays} completedDays - The user's completed days.
+ * @returns {{ count: number, todayCount: number }} - The current date and streak count.
  */
 export const calculateStreakCount = (completedDays) => {
   const today = getChicagoDate()
-  const yesterday = dayjs(today).subtract(1, 'day').format('YYYY-MM-DD')
+  const todayCount = completedDays[today] || 0
+  // If the user completed a task today, the streak is at least 1
+  let count = todayCount > 0 ? 1 : 0
 
-  // Sort dates in descending order, so we can check from yesterday backward
-  const dates = Object.keys(completedDays).sort(
-    (a, b) => new Date(b).getTime() - new Date(a).getTime()
-  )
-
-  let streakCount = 0
-
-  for (const date of dates) {
-    if (date === today) continue // Skip today, only count until yesterday
-
-    if (completedDays[date] > 0 && date <= yesterday) {
-      streakCount++
-    } else {
-      break // Stop counting if a non-completed day is found
-    }
+  // Start from yesterday to avoid counting today twice
+  let currentDate = dayjs(today).subtract(1, 'day').format('YYYY-MM-DD')
+  while (completedDays[currentDate] > 0) {
+    count++
+    currentDate = dayjs(currentDate).subtract(1, 'day').format('YYYY-MM-DD')
   }
 
-  return { today, streakCount }
+  return { count, todayCount }
 }

--- a/src/utils/streakUtils.js
+++ b/src/utils/streakUtils.js
@@ -22,20 +22,20 @@ export const getChicagoDate = () => {
 
 /**
  * Updates the completed days for a user based on the current date.
- * @param {completedDays} completedDays - The completed days map.
+ * @param {import('@/contexts/UserContext').Streak} streak - The user's streak object.
  * @param {number} countChange - 1 or -1 to increment or decrement the count for the current date.
- * @returns {completedDays} - Updated completedDays as a map of date-count pairs.
+ * @returns {import('@/contexts/UserContext').Streak} The updated streak object.
  */
-export const updateStreakDays = (completedDays, countChange) => {
+export const updateStreakDays = (streak, countChange) => {
   const currentDate = getChicagoDate()
 
   // Get the current count for the current date or initialize it to 0
-  const currentCount = completedDays[currentDate] || 0
+  const currentCount = streak.completedDays[currentDate] || 0
 
   // Update the count for the current date
-  completedDays[currentDate] = Math.max(0, currentCount + countChange)
+  streak.completedDays[currentDate] = Math.max(0, currentCount + countChange)
 
-  return completedDays
+  return streak
 }
 
 /**


### PR DESCRIPTION
- `count` and `todayCount` will update every time fetching user profile.
- Update `streakUtils` to calculate streak count based on continuous logic (if a day does not have a count, the streak will loss).

- Update test accordingly.
- Update UserContext'a type declaration accordingly.